### PR TITLE
【Fixed】`rails g`コマンドの際にassetsファイル、helperが作成されない様に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,10 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1  

config/application.rb にhelperとassetsの生成を抑制する設定を追加。